### PR TITLE
Update TemplateWizard.fs

### DIFF
--- a/FsWpfEmptyTemplateWizard/TemplateWizard.fs
+++ b/FsWpfEmptyTemplateWizard/TemplateWizard.fs
@@ -29,7 +29,7 @@ type TemplateWizard() =
                                      Microsoft.VisualStudio.OLE.Interop.IServiceProvider)
             this.destinationPath <- replacementsDictionary.["$destinationdirectory$"]
             this.safeProjectName <- replacementsDictionary.["$safeprojectname$"]
-            this.targetFramework <- Double.Parse replacementsDictionary.["$targetframeworkversion$"]
+            this.targetFramework <- Double.Parse (replacementsDictionary.["$targetframeworkversion$"].Substring(0, 3))
         member this.ProjectFinishedGenerating project = "Not Implemented" |> ignore
         member this.ProjectItemFinishedGenerating projectItem = "Not Implemented" |> ignore
         member this.ShouldAddProjectItem filePath = true


### PR DESCRIPTION
Handle the fact that we can't parse framework versions of the form 4.5.1 into a double.  To handle this case we just take the major part of the version number as it's only used in a later greater than check.
